### PR TITLE
Proxy version

### DIFF
--- a/bld/src/libproxy/CMakeLists.txt
+++ b/bld/src/libproxy/CMakeLists.txt
@@ -285,6 +285,18 @@ if(${use_openssl})
     target_link_libraries(libproxy-static PUBLIC ${OPENSSL_LIBRARIES})
 endif()
 
+# Try to define the verision from the closest parent git tag and the current Git hash.
+find_package(Git)
+if(GIT_EXECUTABLE)
+	execute_process(
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    COMMAND "${GIT_EXECUTABLE}" describe --always --tags --dirty
+    OUTPUT_VARIABLE GIT_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  target_compile_definitions(libproxy PRIVATE SCM_VERSION="${GIT_VERSION}")
+endif()
+
 if(WIN32)
   # Place here the install rule for win32
 elseif(LINUX)

--- a/githooks/post-checkout
+++ b/githooks/post-checkout
@@ -1,0 +1,12 @@
+#!/bin/sh
+# This hook is invoked when a git checkout is run after having updated the worktree.
+# This hook cannot affect the outcome of git checkout.
+# see: man 5 githooks
+# To enable this hook script copy it to $GIT_DIR/hooks/ and chmod +x $GIT_DIR/hooks/post-checkout
+
+# We need to update the time stamp of some files, so that cmake
+# knows to update what ever depends on these files
+
+UPDATE_FILES="$GIT_DIR/../inc/version.h"
+echo "Touching $UPDATE_FILES"
+touch $UPDATE_FILES

--- a/githooks/post-checkout
+++ b/githooks/post-checkout
@@ -7,6 +7,6 @@
 # We need to update the time stamp of some files, so that cmake
 # knows to update what ever depends on these files
 
-UPDATE_FILES="$GIT_DIR/../inc/version.h"
+UPDATE_FILES="$GIT_DIR/../bld/src/libproxy/CMakeLists.txt"
 echo "Touching $UPDATE_FILES"
 touch $UPDATE_FILES

--- a/githooks/post-commit
+++ b/githooks/post-commit
@@ -7,6 +7,6 @@
 # We need to update the time stamp of some files, so that cmake
 # knows to update what ever depends on these files
 
-UPDATE_FILES="$GIT_DIR/../inc/version.h"
+UPDATE_FILES="$GIT_DIR/../bld/src/libproxy/CMakeLists.txt"
 echo "Touching $UPDATE_FILES"
 touch $UPDATE_FILES

--- a/githooks/post-commit
+++ b/githooks/post-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+# This hook is invoked by git commit. It takes no parameter, and is invoked after a commit is made.
+# This hook is meant primarily for notification, and cannot affect the outcome of git commit.
+# see: man 5 githooks
+# To enable this hook script copy it to $GIT_DIR/hooks/ and chmod +x $GIT_DIR/hooks/post-commit
+
+# We need to update the time stamp of some files, so that cmake
+# knows to update what ever depends on these files
+
+UPDATE_FILES="$GIT_DIR/../inc/version.h"
+echo "Touching $UPDATE_FILES"
+touch $UPDATE_FILES

--- a/inc/version.h
+++ b/inc/version.h
@@ -20,11 +20,18 @@
 #define _TOSTRING_(x) #x
 #define _TOSTRING(x) _TOSTRING_(x)
 
+#if defined(SCM_VERSION)
+#  define SCM_VERSION_APPEND " - " SCM_VERSION
+#else
+#  define SCM_VERSION_APPEND ""
+#endif
+
 // Stringified version
 #define MODULE_VERSION \
-     "" _TOSTRING_(MODULE_MAJ_VER) \
-    "." _TOSTRING_(MODULE_MIN_VER) \
-    "." _TOSTRING_(MODULE_REL_VER)
+     "" _TOSTRING(MODULE_MAJ_VER) \
+    "." _TOSTRING(MODULE_MIN_VER) \
+    "." _TOSTRING(MODULE_REL_VER) \
+     SCM_VERSION_APPEND
 
 #define MODULE_NAME "iot-gateway-proxy"
 

--- a/src/prx_host.c
+++ b/src/prx_host.c
@@ -241,7 +241,7 @@ static int32_t prx_host_init_from_command_line(
         while (result == er_ok)
         {
             c = getopt_long(
-                argc, argv, "hiuc:t:n:L:l:C:d:", long_options, &option_index);
+                argc, argv, "hiuc:t:n:L:l:C:D:", long_options, &option_index);
             if (c == -1)
                 break;
 

--- a/src/prx_host.c
+++ b/src/prx_host.c
@@ -231,6 +231,7 @@ static int32_t prx_host_init_from_command_line(
         { "connection-string-file",     required_argument,      NULL, 'C' },
         { "hub-config-file",            required_argument,      NULL, 'H' },
         { "ns-db-file",                 required_argument,      NULL, 'D' },
+        { "version",                    no_argument,            NULL, 'v' },
         { 0,                            0,                      NULL,  0  }
     };
 
@@ -257,6 +258,11 @@ static int32_t prx_host_init_from_command_line(
             case 'u':
                 should_exit = true;
                 is_uninstall = true;
+                break;
+            case 'v':
+#if defined(SCM_VERSION)
+                printf("Version: " SCM_VERSION "\n");
+#endif
                 break;
 #if defined(DEBUG)
             case 't':

--- a/src/prx_host.c
+++ b/src/prx_host.c
@@ -18,6 +18,7 @@
 
 #include "azure_c_shared_utility/doublylinkedlist.h"
 #include "azure_c_shared_utility/refcount.h"
+#include "version.h"
 
 #include <stdio.h>
 #include "getopt.h"
@@ -260,8 +261,8 @@ static int32_t prx_host_init_from_command_line(
                 is_uninstall = true;
                 break;
             case 'v':
-#if defined(SCM_VERSION)
-                printf("Version: " SCM_VERSION "\n");
+#if defined(MODULE_VERSION)
+                printf("Version: " MODULE_VERSION "\n");
 #endif
                 break;
 #if defined(DEBUG)


### PR DESCRIPTION
This pull request adds the command line options -v | --version to the proxyd program.
Which will print the current version to stdout.
The current version is derived from the `git describe` command. For full benefit of this, versions like .0.0.7 should be tagged with the `git tag` command.

Greetings
                  Juergen