### PR TITLE
Initialize the whole *proxy_address buffer

### DIFF
--- a/src/pal/pal_ws_lws.c
+++ b/src/pal/pal_ws_lws.c
@@ -1065,7 +1065,7 @@ static int32_t pal_wsworker_get_proxy_info(
     if (!*proxy_address)
         return er_out_of_memory;
 
-    *proxy_address = 0;
+    memset(*proxy_address, 0, buf_len);
     // Concat proxy address string
     if (user)
     {


### PR DESCRIPTION
The whole *proxy_address buffer needs to be initialized to 0.
Otherwise strcat() would cause a segmentation fault.

Signed-off-by: Juergen Kosel <juergen.kosel@softing.com>