### PR TITLE
Workaround for issue #32

### DIFF
--- a/src/pal/pal_net_posix.c
+++ b/src/pal/pal_net_posix.c
@@ -28,7 +28,10 @@ int32_t pal_os_to_prx_gai_error(
     case EAI_BADFLAGS:      
         return er_bad_flags;
     case EAI_FAMILY:
+#ifdef EAI_ADDRFAMILY
+        // EAI_ADDRFAMILY is defined in netdb.h if __USE_GNU is defined
     case EAI_ADDRFAMILY:
+#endif
         return er_address_family;
     case EAI_NONAME:     
         return er_host_unknown;
@@ -961,7 +964,11 @@ int32_t pal_getaddrinfo(
         // Workaround for issue #32
         // The connect message wants always AF_INET even if the requested
         // address is an IPv6 address
-        if ((result == EAI_ADDRFAMILY) || (family == EAI_FAMILY))
+        if (
+#ifdef EAI_ADDRFAMILY
+            (result == EAI_ADDRFAMILY) ||
+#endif
+            (family == EAI_FAMILY))
         {
             if (hint.ai_family == AF_INET)
             {

--- a/src/pal/pal_net_posix.c
+++ b/src/pal/pal_net_posix.c
@@ -958,6 +958,17 @@ int32_t pal_getaddrinfo(
         if (result == 0)
             break;
 
+        // Workaround for issue #32
+        // The connect message wants always AF_INET even if the requested
+        // address is an IPv6 address
+        if ((result == EAI_ADDRFAMILY) || (family == EAI_FAMILY))
+        {
+            if (hint.ai_family == AF_INET)
+            {
+                hint.ai_family = AF_INET6;
+                continue; // try again with IPv6, if IPv4 has failed
+            }
+        }
         // Intermittent dns outages can result in E_AGAIN, try 3 times
 #define GAI_MAX_ATTEMPTS 3
         if (result != EAI_AGAIN || attempt++ >= GAI_MAX_ATTEMPTS)

--- a/src/pal/pal_net_posix.c
+++ b/src/pal/pal_net_posix.c
@@ -938,6 +938,7 @@ int32_t pal_getaddrinfo(
     *prx_ai_count = 0;
     *prx_ai = NULL;
 
+    log_info(NULL, "getaddrinfo for \"%s\", \"%s\" family: %d",address,service,family);
     // Get all address families and the canonical name
     memset(&hint, 0, sizeof(hint));
 

--- a/src/pal/pal_net_posix.c
+++ b/src/pal/pal_net_posix.c
@@ -27,7 +27,8 @@ int32_t pal_os_to_prx_gai_error(
         return er_retry;
     case EAI_BADFLAGS:      
         return er_bad_flags;
-    case EAI_FAMILY:       
+    case EAI_FAMILY:
+    case EAI_ADDRFAMILY:
         return er_address_family;
     case EAI_NONAME:     
         return er_host_unknown;


### PR DESCRIPTION
This pull request provides a workaround for issue #32 
The root cause of the issue is in the client or the protocol.
Because the opc.ua sample client requests always address family AF_INET, even if the client request a connection to an IPv6 IP address!
